### PR TITLE
Fix undefined webvttstoragemanager

### DIFF
--- a/main.js
+++ b/main.js
@@ -28,9 +28,9 @@ async function register ({registerHook, registerSetting, settingsManager, storag
           const webVtt = toWebVtt(parsed)
           storageManager.storeData(tableOfContentsField + '_vtt' + '_v-' + video.id, webVtt)
         }
-      }else {
-        webVttstorageManager.storeData(tableOfContentsField + '_parsed' + '_v-' + video.id, null)
-        webVttstorageManager.storeData(tableOfContentsField + '_vtt' + '_v-' + video.id, null)
+      } else {
+        storageManager.storeData(tableOfContentsField + '_parsed' + '_v-' + video.id, null)
+        storageManager.storeData(tableOfContentsField + '_vtt' + '_v-' + video.id, null)
       }
     }
   })


### PR DESCRIPTION
Hi,

I've installed your plugin on some PeerTube instance (3.1.0), as it was requested by one of my users.
Now, I realize that from time to time, PeerTube would lock traces such as the following:

```
May 15 07:30:32 peertube-1.scaleway.example.com docker-compose[25455]: peertube_1  | [video.example.com:443] 2021-05-15 05:30:32.598 error: Cannot run hook action:api.video.updated of plugin chapters. {
May 15 07:30:32 peertube-1.scaleway.example.com docker-compose[25455]: peertube_1  |   "err": {
May 15 07:30:32 peertube-1.scaleway.example.com docker-compose[25455]: peertube_1  |     "stack": "ReferenceError: webVttstorageManager is not defined\n    at handler (/data/plugins/node_modules/peertube-plugin-chapters/main.js:32:9)\n    at Object.<anonymous> (/app/dist/shared/core-utils/plugins/hooks.js:25:23)\n    at Generator.next (<anonymous>)\n    at /app/node_modules/tslib/tslib.js:117:75\n    at new Promise (<anonymous>)\n    at Object.__awaiter (/app/node_modules/tslib/tslib.js:113:16)\n    at Object.internalRunHook (/app/dist/shared/core-utils/plugins/hooks.js:15:20)\n    at PluginManager.<anonymous> (/app/dist/server/lib/plugins/plugin-manager.js:145:40)\n    at Generator.next (<anonymous>)\n    at /app/node_modules/tslib/tslib.js:117:75\n    at new Promise (<anonymous>)\n    at Object.__awaiter (/app/node_modules/tslib/tslib.js:113:16)\n    at PluginManager.runHook (/app/dist/server/lib/plugins/plugin-manager.js:139:24)\n    at Object.runAction (/app/dist/server/lib/plugins/hooks.js:20:49)\n    at /app/dist/server/controllers/api/videos/index.js:272:27\n    at Generator.next (<anonymous>)\n    at fulfilled (/app/node_modules/tslib/tslib.js:114:62)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)",
May 15 07:30:32 peertube-1.scaleway.example.com docker-compose[25455]: peertube_1  |     "message": "webVttstorageManager is not defined"
May 15 07:30:32 peertube-1.scaleway.example.com docker-compose[25455]: peertube_1  |   }
May 15 07:30:32 peertube-1.scaleway.example.com docker-compose[25455]: peertube_1  |
```

TBH, I'm not sure it's broken. Users seems to be happy anyway, though it's been there only for a short while, I haven't heard anyone complaining.
Still, I'ld rather avoid logging errors when there's nothing to worry about.

Are those modifications OK? Is this actually what you meant, or am I missing something?